### PR TITLE
mimemagicのバージョンを上げる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "sass-rails", "~> 5"
 gem "webpacker", "~> 4.0"
 gem "turbolinks", "~> 5"
 gem "jbuilder", "~> 2.7"
+gem "mimemagic", "~> 0.3.10"
 
 gem "bootsnap", ">= 1.4.2", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.13.0)
@@ -254,6 +256,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   kaminari
   listen (>= 3.0.5, < 3.2)
+  mimemagic (~> 0.3.10)
   nokogiri
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)


### PR DESCRIPTION
@kuroda こんにちは！良い本をありがとうございます！

先日のRails mimemagic問題の影響で`bin/bundle`がコケていたので対処としてmimemagicのバージョンを上げました。こちら確認よろしくおねがいします。

(向き先のブランチはここでしょうか)

## 実施作業
1. Gemefileにmimemagicの行を追加
2. webコンテナ内でbin/bundle update mimemagicを実行

## コンテナ側
https://github.com/oiax/rails6-compose/pull/8
コンテナ側にshared-mime-infoパッケージをインストールしております。